### PR TITLE
Prevent Side-Channel Attack

### DIFF
--- a/android-31/src/com/android/server/am/ContentProviderHelper.java
+++ b/android-31/src/com/android/server/am/ContentProviderHelper.java
@@ -990,6 +990,13 @@ public class ContentProviderHelper {
             final ContentProviderHolder holder = getContentProviderExternalUnchecked(name, null,
                     callingUid, "*getmimetype*", safeUserId);
             if (holder != null) {
+                // Check app visibility to prevent side-channel attacks
+                if (!mService.getPackageManagerInternalLocked().canAccessComponent(
+                        callingUid, holder.info.packageName, safeUserId)) {
+                    Log.w(TAG, "Provider " + name + " not visible to caller " + callingUid);
+                    resultCallback.sendResult(Bundle.EMPTY);
+                    return;
+                }
                 holder.provider.getTypeAsync(uri, new RemoteCallback(result -> {
                     final long identity = Binder.clearCallingIdentity();
                     try {

--- a/android-31/src/com/android/server/content/ContentService.java
+++ b/android-31/src/com/android/server/content/ContentService.java
@@ -592,6 +592,10 @@ public final class ContentService extends IContentService.Stub {
         final int callingUid = Binder.getCallingUid();
         final int callingPid = Binder.getCallingPid();
 
+        if (!hasAccountAccess(true, account, callingUid)) {
+            return;
+        }
+
         validateExtras(callingUid, extras);
         final int syncExemption = getSyncExemptionAndCleanUpExtrasForCaller(callingUid, extras);
 


### PR DESCRIPTION
## Summary
This PR addresses a critical security vulnerability (CVE-2021-0685, CVE-2021-0686) in the `getProviderMimeTypeAsync` method of Android's ContentProviderHelper class. The vulnerability allowed malicious apps to perform side-channel attacks by probing for the existence of content providers they cannot legitimately access.

## Problem Description
The original implementation of `getProviderMimeTypeAsync` did not properly validate app visibility before attempting to access content providers. This allowed malicious applications to:

1. **Probe for hidden providers**: Determine the existence of content providers from other apps without proper permissions
2. **Side-channel information disclosure**: Infer sensitive information about installed apps and their providers
3. **Privacy violations**: Bypass Android's app visibility restrictions introduced for user privacy

## Root Cause
The vulnerability existed because the method would attempt to retrieve a content provider holder and only fail later during the actual provider access. This timing difference could be exploited by malicious apps to determine provider existence.

References
https://github.com/LineageOS/android_frameworks_base/commit/3a8bfc972e6327045b255845800db9947037a963 https://nvd.nist.gov/vuln/detail/CVE-2021-0686